### PR TITLE
chore(update): org.gnome.Platform 41

### DIFF
--- a/de.haeckerfelix.Fragments.json
+++ b/de.haeckerfelix.Fragments.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "de.haeckerfelix.Fragments",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "40",
+    "runtime-version" : "41",
     "sdk" : "org.gnome.Sdk",
     "command" : "fragments",
     "finish-args" : [

--- a/de.haeckerfelix.Fragments.json
+++ b/de.haeckerfelix.Fragments.json
@@ -101,21 +101,6 @@
             ]
         },
         {
-            "name" : "libhandy",
-            "buildsystem" : "meson",
-            "config-opts": [
-                    "-Dglade_catalog=disabled",
-                    "-Dintrospection=enabled",
-                    "-Dexamples=false",
-                    "-Dtests=false"
-            ],
-            "sources" : [{
-                    "type" : "git",
-                    "url" : "https://gitlab.gnome.org/GNOME/libhandy",
-                    "tag": "1.0.0"
-            }]
-        },
-        {
             "name" : "fragments",
             "buildsystem" : "meson",
             "sources" : [{


### PR DESCRIPTION
Update to latest GNOME runtime and also drop libhandy dep. Libhandy now is a part of new GNOME runtime.